### PR TITLE
Change Toolforge to Cloud VPS link for pageviews

### DIFF
--- a/dist/MoreMenu.page.js
+++ b/dist/MoreMenu.page.js
@@ -108,7 +108,7 @@ window.MoreMenu.page = function (config) {
           pageExists: true
         },
         'traffic-report': {
-          url: "https://pageviews.toolforge.org?project=".concat(config.project.domain, "&pages=").concat(config.page.encodedName),
+          url: "https://pageviews.wmcloud.org?project=".concat(config.project.domain, "&pages=").concat(config.page.encodedName),
           pageExists: true
         },
         'transclusion-count': {

--- a/src/MoreMenu.page.js
+++ b/src/MoreMenu.page.js
@@ -61,7 +61,7 @@ window.MoreMenu.page = config => ({
                 pageExists: true,
             },
             'traffic-report': {
-                url: `https://pageviews.toolforge.org?project=${config.project.domain}&pages=${config.page.encodedName}`,
+                url: `https://pageviews.wmcloud.org?project=${config.project.domain}&pages=${config.page.encodedName}`,
                 pageExists: true,
             },
             'transclusion-count': {


### PR DESCRIPTION
This avoids an unnecessary redirect.