### PR TITLE
Fix link to page deletion on WhatLinksHere etc.

### DIFF
--- a/src/MoreMenu.page.js
+++ b/src/MoreMenu.page.js
@@ -135,7 +135,7 @@ window.MoreMenu.page = config => ({
         },
         'delete-page': {
             /** NOTE: must use `decodeURIComponent` because mw.util.getUrl will otherwise double-escape. This should be safe. */
-            url: mw.util.getUrl(null, { action: 'delete', 'wpReason': decodeURIComponent($('#delete-reason').text()).replace(/\+/g, ' ') }),
+            url: mw.util.getUrl(config.page.name, { action: 'delete', 'wpReason': decodeURIComponent($('#delete-reason').text()).replace(/\+/g, ' ') }),
             currentUserRights: ['delete'],
             pageExists: true,
             visible: !mw.config.get('wgIsMainPage'),


### PR DESCRIPTION
Use `wgRelevantPageName` instead of `wgPageName` in link to page deletion on special pages like WhatLinksHere.

Reported at https://meta.wikimedia.org/wiki/Talk:MoreMenu#Regarding_WhatLinksHere_and_Delete