### PR TITLE
Use HTTPS for WikiBlame

### DIFF
--- a/src/MoreMenu.page.js
+++ b/src/MoreMenu.page.js
@@ -83,7 +83,7 @@ window.MoreMenu.page = config => ({
                 pageExists: true,
             },
             'search-history-wikiblame': {
-                url: `http://wikipedia.ramselehof.de/wikiblame.php?lang=${config.project.contentLanguage}&project=${config.project.noticeProject}&article=${config.page.encodedName}`,
+                url: `https://wikipedia.ramselehof.de/wikiblame.php?lang=${config.project.contentLanguage}&project=${config.project.noticeProject}&article=${config.page.encodedName}`,
                 pageExists: true,
             },
             'search-history-xtools': {


### PR DESCRIPTION
WikiBlame now supports HTTPS, but doesn't automatically redirect.