### PR TITLE
update usage of spur.us for IP lookup

### DIFF
--- a/src/MoreMenu.user.js
+++ b/src/MoreMenu.user.js
@@ -150,7 +150,7 @@ window.MoreMenu.user = ( config ) => ( {
 		},
 		'ip-lookup': {
 			'spur': {
-				url: `https://spur.us/app/context?q=${ config.targetUser.name }`,
+				url: `https://app.spur.us/search?q=${ config.targetUser.name }`,
 				targetUserIp: true,
 				targetUserIpRange: false,
 				currentUserGroups: [ 'user' ]


### PR DESCRIPTION
Now uses a subdomain and different subdirectory